### PR TITLE
Add missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,30 @@ Requirements
 cve-portal requires [cve-search](https://github.com/adulau/cve-search) to be installed
 for the CVE (Common Vulnerabilities and Exposures) and CPE (Common Platform Enumeration) back-end.
 
+The installationscript will install the following packages on your system
+ * python-mysqldb
+ * libmysqlclient-dev
+ * python-dev
+ * unzip
+ * python-virtualenv
+ * git
+
+The pip requirements.txt script will install the following packages on your system
+ * flask
+ * flask-bootstrap
+ * flask-wtf
+ * flask-login
+ * flask-SQLAlchemy
+ * mysql-python
+ * flask-script
+ * flask-mail
+ * flask-scrypt
+ * https://github.com/isislovecruft/python-gnupg.git
+ * redis
+ * flask-pymongo
+ * whoosh
+ * gunicorn
+
 License
 =======
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The installationscript will install the following packages on your system
  * unzip
  * python-virtualenv
  * git
+ * libssl-dev
 
 The pip requirements.txt script will install the following packages on your system
  * flask

--- a/app/install.sh
+++ b/app/install.sh
@@ -6,7 +6,7 @@ set -e
 sudo apt-get update
 
 
-sudo apt-get install python-mysqldb libmysqlclient-dev python-dev unzip python-virtualenv git
+sudo apt-get install python-mysqldb libmysqlclient-dev python-dev unzip python-virtualenv git python-pip libssl-dev
 
 virtualenv virtenv
 


### PR DESCRIPTION
Installing scrypt failed without libssl-dev, so I figured, as it will not be default for everyone, adding it to the install script would be a good idea